### PR TITLE
Adding positive z-index to header

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -79,6 +79,7 @@ body {
     width: 1024px;
     font-size: 100%;
     background: #4040ff;
+    z-index: 1;
 
     a {
         display: inline-block;


### PR DESCRIPTION
such that it will correctly render on top of content

Before:
![image](https://user-images.githubusercontent.com/16867443/69892375-d2f62400-12d2-11ea-8f02-a0ffb633131a.png)

After:
![image](https://user-images.githubusercontent.com/16867443/69892383-ec976b80-12d2-11ea-8d4b-e70c1a60bb2e.png)

