### PR TITLE
Upload rendered site to external server rather than push back to gh-pages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           node-version: '12.x'
       - name: Setup
-        run: make distclean build-tools
+        run: make distclean lint-tools
       - name: Lint
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Make site
         run: make site
       - name: Env Test
-        run: make upload
+        run: |
+            cat .scripts/scripts.mk
+            make upload
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }} 
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: gh-pages
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
@@ -30,16 +28,13 @@ jobs:
       - name: Install Bundler
         run: gem install bundler
       - name: Setup 
-        run: |
-            make distclean 
-            bash -x .init-scripts/make-build-tools.sh
-            cat .scripts/scripts.mk
-      - name: Build
+        run: make distclean build-tools
+      - name: Build site
         run: make build
       - name: Remove source-repo
         run: rm -rf source-repo/
-      - name: Make site
-        run: make site
+        #      - name: Make site
+        #        run: make site
       - name: Make upload
         run: |
             cat .scripts/scripts.mk

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,15 +37,6 @@ jobs:
         run: rm -rf source-repo/
       - name: Make site
         run: make site
-      - name: Remove old site from server
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            date > timestamp.txt
-            rm -rf _site
       - name: Upload site to server
         uses: appleboy/scp-action@master
         with:
@@ -53,4 +44,5 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: "_site"
-          target: "_site"
+          target: "var/www/${{ secrets.SSH_HOST }}/nmos-template"
+          strip_components: 1

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -44,5 +44,16 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: "_site"
-          target: "var/www/${{ secrets.SSH_HOST }}/nmos-template"
+          target: "var/www/${{ secrets.SSH_HOST }}/nmos-template.new"
           strip_components: 1
+      - name: Replace old site
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            mv "var/www/${{ secrets.SSH_HOST }}/nmos-template{,.old}"
+            mv "var/www/${{ secrets.SSH_HOST }}/nmos-template{.new,}"
+            rm -rf "var/www/${{ secrets.SSH_HOST }}/nmos-template.old"
+

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -43,3 +43,4 @@ jobs:
           SSH_HOST: ${{ secrets.SSH_HOST }} 
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -31,14 +31,8 @@ jobs:
         run: make distclean build-tools
       - name: Build site
         run: make build
-      - name: Remove source-repo
-        run: rm -rf source-repo/
-        #      - name: Make site
-        #        run: make site
       - name: Make upload
-        run: |
-            cat .scripts/scripts.mk
-            make upload
+        run: make upload
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }} 
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -53,7 +53,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            mv "var/www/${{ secrets.SSH_HOST }}/nmos-template{,.old}"
-            mv "var/www/${{ secrets.SSH_HOST }}/nmos-template{.new,}"
-            rm -rf "var/www/${{ secrets.SSH_HOST }}/nmos-template.old"
+            cd "var/www/${{ secrets.SSH_HOST }}/"
+            mv "nmos-template nmos-template.old"
+            mv "nmos-template.new nmos-template"
+            rm -rf "nmos-template.old"
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -52,5 +52,5 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-        source: "_site"
-        target: "_site"
+          source: "_site"
+          target: "_site"

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,9 +37,20 @@ jobs:
         run: rm -rf source-repo/
       - name: Make site
         run: make site
-  upload:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Can we see _site
-        run: ls
+      - name: Remove old site from server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            date > timestamp.txt
+            rm -rf _site
+      - name: Upload site to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+        source: "_site"
+        target: "_site"

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup 
         run: |
             make distclean 
-            bash -x .init-scripts/make-build-tools
+            bash -x .init-scripts/make-build-tools.sh
             cat .scripts/scripts.mk
       - name: Build
         run: make build

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Ruby
         uses: actions/setup-ruby@v1
         with:
-            ruby-version '2.x'
+          ruby-version: '2.x'
       - name: Install Bundler
         run: gem install bundler
       - name: Setup 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -30,14 +30,17 @@ jobs:
       - name: Install Bundler
         run: gem install bundler
       - name: Setup 
-        run: make distclean build-tools
+        run: |
+            make distclean 
+            make build-tools
+            cat .scripts/scripts.mk
       - name: Build
         run: make build
       - name: Remove source-repo
         run: rm -rf source-repo/
       - name: Make site
         run: make site
-      - name: Env Test
+      - name: Make upload
         run: |
             cat .scripts/scripts.mk
             make upload

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup 
         run: |
             make distclean 
-            make build-tools
+            bash -x .init-scripts/make-build-tools
             cat .scripts/scripts.mk
       - name: Build
         run: make build

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,24 +37,9 @@ jobs:
         run: rm -rf source-repo/
       - name: Make site
         run: make site
-      - name: Upload site to server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "_site"
-          target: "var/www/${{ secrets.SSH_HOST }}/nmos-template.new"
-          strip_components: 1
-      - name: Replace old site
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            cd "var/www/${{ secrets.SSH_HOST }}/"
-            mv "nmos-template nmos-template.old"
-            mv "nmos-template.new nmos-template"
-            rm -rf "nmos-template.old"
-
+      - name: Env Test
+        run: make upload
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }} 
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,3 +37,9 @@ jobs:
         run: rm -rf source-repo/
       - name: Make site
         run: make site
+  upload:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Can we see _site
+        run: ls

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -31,7 +31,7 @@ jobs:
         run: make distclean build-tools
       - name: Build site
         run: make build
-      - name: Make upload
+      - name: Upload site
         run: make upload
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }} 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -15,34 +15,25 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: gh-pages
-      - name: Use Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Uses Python
+      - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Setup
+      - name: Install Ruby
+        uses: actions/setup-ruby@v1
+        with:
+            ruby-version '2.x'
+      - name: Install Bundler
+        run: gem install bundler
+      - name: Setup 
         run: make distclean build-tools
       - name: Build
         run: make build
       - name: Remove source-repo
         run: rm -rf source-repo/
-      - name: Add and Commit
-        uses: EndBug/add-and-commit@v5
-        with:
-          author_name: AMWA
-          author_email: info@amwa.tv
-          message: "Build for Github Pages"
-          add: '.'
-          branch: gh-pages
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-
-
+      - name: Make site
+        run: make site

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ yarn.lock
 .ssh/
 Gemfile.lock
 raml2html-nmos-theme/
+_site/
+assets/
+branches/
+index.md
+source-repo/
+tags/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules/
 package.json
 yarn.lock
 .scripts/
+.ssh/
+Gemfile.lock
+raml2html-nmos-theme/

--- a/.init-scripts/make-build-tools.sh
+++ b/.init-scripts/make-build-tools.sh
@@ -2,5 +2,5 @@
 
 set -o errexit
 
-git clone https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-lint-scripts .scripts
+git clone --single-branch --branch external-site https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
 .scripts/install-dependencies.sh

--- a/.init-scripts/make-distclean.sh
+++ b/.init-scripts/make-distclean.sh
@@ -2,4 +2,5 @@
 
 set -o errexit
 
-rm -rf package.json node_modules/ yarn.lock package-lock.json .scripts/
+rm -rf source-repo branches tags index.md index-contents.md
+rm -rf node_modules/ yarn.lock package-lock.json .scripts/ .layouts/ _layouts/ assets/ raml2html-nmos-theme/

--- a/.init-scripts/make-distclean.sh
+++ b/.init-scripts/make-distclean.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 rm -rf source-repo branches tags index.md index-contents.md
-rm -rf node_modules/ yarn.lock package-lock.json .scripts/ .layouts/ _layouts/ assets/ raml2html-nmos-theme/
+rm -rf node_modules/ yarn.lock package-lock.json .scripts/ .layouts/ _layouts/ assets/ raml2html-nmos-theme/ _site/

--- a/.init-scripts/make-lint-tools.sh
+++ b/.init-scripts/make-lint-tools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit
+
+git clone https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-lint-scripts .scripts
+.scripts/install-dependencies.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins
+gem 'faraday', '~>0'

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 AMWA
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 -include .scripts/scripts.mk
 
-.PHONY: build-tools distclean
+.PHONY: lint-tools build-tools distclean
+
+lint-tools:
+	./.init-scripts/make-lint-tools.sh
 
 build-tools:
 	./.init-scripts/make-build-tools.sh

--- a/README-gh-pages.md
+++ b/README-gh-pages.md
@@ -1,0 +1,69 @@
+# AMWA NMOS Template Specification
+
+## GitHub Pages documentation
+
+> NOTE: We are moving to hosting spec documentation on an external server, rather than GitHub Pages.
+> This page was formerly README.md on the gh-pages branch and will be removed in the future.
+
+If you are reading this you are on the gh-pages branch, which is used to generate the documentation from the master and other branches, and from releases.  These are served at <https://specs.amwa.tv/nmos-template/>.
+
+## Generating the documentation
+
+If you make any changes to the repo please do the following:
+
+Clone this repo (if you haven't already), checkout the gh-pages branch:
+
+``git checkout gh-pages``
+
+Install build tools (raml2html, jsonlint, now installed locally):
+
+``make build-tools``
+
+Make the documentation:
+
+``make``
+
+This runs scripts to:
+
+- clone the repo from AMWA's GitHub
+- for each branch and release (with some exceptions) extract documentation, APIs and schemas
+  - making HTML renders of the RAML APIs
+- for each branch and release create indexes for the documentation, APIs and schemas
+- make links to what will later be the HTML renders of the Markdown documentation
+
+## Updating AMWA's GitHub
+
+You can push the updated documentation to AMWA's GitHub with.
+
+``make push``
+
+Alternatively commit and push manually for more control of the commit message.
+
+Admins must be to do this after merging PRs etc (until this is automated with CircleCI at some point).
+
+This then triggers a build of the GitHub Pages. This happens on GitHub's servers, using Jekyll to render the HTML.  This includes rendering the Markdown content, but we have to do the RAML ourselves.  
+
+To clean up:
+
+``make clean``
+
+To also remove the build tools:
+
+``make distclean``
+
+## Serving pages locally
+
+See also <https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll>
+
+Install Bundler and Jekyll - af you have Ruby installed then:
+
+``gem install bundler``
+
+``bundle install``
+
+Run server with:
+
+``make server``
+
+And browse to <http://127.0.0.1:4000>.
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,16 @@
+# Don't change these
+theme: jekyll-theme-primer
+spec_server: specs.amwa.tv
+
+# AMWA ID
+amwa_id: IS-TEMPLATE
+
+# Base name for site (typically lower case version of AMWA ID, or the repo name)
+baseurl: /is-template
+
+# Which relase or branch appears in header links and on the home page
+default_tree: branches/v1.0-dev # alternatively e.g. tags/v1.0
+
+# Regex patterns of tags (releases) and branches to show
+show_tags: v[0-9]+\.[0-9]+|v[0-9]+\.[0-9]+
+show_branches: v[0-9]+\.[0-9]+-dev|v[0-9]+\.[0-9]+\.x|publish-*

--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,5 @@ baseurl: /is-template
 default_tree: branches/v1.0-dev # alternatively e.g. tags/v1.0
 
 # Regex patterns of tags (releases) and branches to show
-show_tags: v[0-9]+\.[0-9]+|v[0-9]+\.[0-9]+
-show_branches: v[0-9]+\.[0-9]+-dev|v[0-9]+\.[0-9]+\.x|publish-*
+show_tags: ^v[0-9]+\.[0-9]+$|^v[0-9]+\.[0-9]+\.[0-9]+$
+show_branches: ^v[0-9]+\.[0-9]+-dev$|^v[0-9]+\.[0-9]+\.x$|^publish-

--- a/docs/2.1 Another Thing.md
+++ b/docs/2.1 Another Thing.md
@@ -1,3 +1,0 @@
-# Another Thing
-
-This file is here for testing automation.  Look at the main NMOS page for more information on NMOS!

--- a/docs/2.1 Another Thing.md
+++ b/docs/2.1 Another Thing.md
@@ -1,0 +1,3 @@
+# Another Thing
+
+This file is here for testing automation.  Look at the main NMOS page for more information on NMOS!

--- a/intro.md
+++ b/intro.md
@@ -1,0 +1,13 @@
+### What does it do?
+
+- It provides a template for AMWA NMOS Specifcations.
+
+### Why does it matter?
+
+- It helps ensure consistency between NMOS Specifications.
+- It helps us test our continuous integration.
+
+### How does it work?
+
+- It contains examples of documentation, API, schemas, and examples.
+- These are rendered to HTML and uploaded to specs.amwa.tv


### PR DESCRIPTION
Previously we've been building documentation renders on the gh-page branch and pushing that, so it was rendered on https://amwa-tv.github.io/nmos-template.  We're moving to serving AMWA specs from specs.amwa.tv, so this PR adds scripts to build the site and upload it (using GitHub secrets for ssh and scp). 

Currently this clones the external-site branch of nmos-doc-build-scripts to help testing Remove the `--branch external-site` from .init-scripts/make-build-tools.sh before merging.

Once this is done and AMWA has moved to the new site we won't need the gh-pages branch.