### PR TITLE
example.api.com -> api.example.com

### DIFF
--- a/APIs/TemplateAPI.raml
+++ b/APIs/TemplateAPI.raml
@@ -4,7 +4,7 @@
 # (c) AMWA 2018
 
 title: Example
-baseUri: http://example.api.com/x-nmos/example/{version}
+baseUri: http://api.example.com/x-nmos/example/{version}
 version: v1.0
 mediaType: application/json
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2606#section-3, https://tools.ietf.org/html/rfc6761#section-6.5 (https://github.com/AMWA-TV/nmos-discovery-registration/pull/164)