### PR TITLE
Use nmos-render docker

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     steps:
       - name: Use NMOS Render
-        uses: docker://peterbrightwell/nmos-render:latest
+        uses: docker://amwa/nmos-render:latest
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -14,25 +14,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.x'
-      - name: Install Bundler
-        run: gem install bundler
-      - name: Setup 
-        run: make -C .render distclean build-tools
+      - name: Use NMOS Render
+        uses: peterbrightwell/nmos-render
       - name: Build site
         run: make -C .render build
       - name: Upload site

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,4 +17,4 @@ jobs:
     name: Build
     steps:
       - name: Use NMOS Render
-        uses: STandon-3/nmos-docker-test@latest
+        uses: docker://peterbrightwell/nmos-render:latest

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,13 +17,4 @@ jobs:
     name: Build
     steps:
       - name: Use NMOS Render
-        uses: peterbrightwell/nmos-render
-      - name: Build site
-        run: make -C .render build
-      - name: Upload site
-        run: make -C .render upload
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }} 
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        uses: STandon-3/nmos-docker-test

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -18,5 +18,3 @@ jobs:
     steps:
       - name: Use NMOS Render
         uses: docker://peterbrightwell/nmos-render:latest
-      - name: Clone
-        run: git clone https://github.com/peterbrightwell/nmos-template /nmos-template

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,4 +17,4 @@ jobs:
     name: Build
     steps:
       - name: Use NMOS Render
-        uses: STandon-3/nmos-docker-test
+        uses: STandon-3/nmos-docker-test@latest

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -18,3 +18,8 @@ jobs:
     steps:
       - name: Use NMOS Render
         uses: docker://peterbrightwell/nmos-render:latest
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -18,3 +18,5 @@ jobs:
     steps:
       - name: Use NMOS Render
         uses: docker://peterbrightwell/nmos-render:latest
+      - name: Clone
+        run: git clone https://github.com/peterbrightwell/nmos-template /nmos-template

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -2,5 +2,4 @@
 
 set -o errexit
 
-git clone --single-branch --branch deploy-action https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
-.scripts/install-dependencies.sh
+git clone --single-branch --branch "${NMOS_DOC_BUILD_SCRIPTS_BRANCH:-main}" https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -3,3 +3,4 @@
 set -o errexit
 
 git clone --single-branch --branch deploy-action https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
+.scripts/install-dependencies.sh

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -3,4 +3,3 @@
 set -o errexit
 
 git clone --single-branch --branch main https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
-.scripts/install-dependencies.sh

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -2,4 +2,4 @@
 
 set -o errexit
 
-git clone --single-branch --branch main https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
+git clone --single-branch --branch deploy-action https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts


### PR DESCRIPTION
Use amwa/nmos-deploy docker container to save installing node, ruby, python, jekyll, raml2html etc and the build scripts each time.

Thanks to @STandon-3 for doing the hard work on this.

See also https://github.com/AMWA-TV/nmos-doc-build-scripts/pull/42
